### PR TITLE
added fallback mechanic in case of missing active element (IE11 bug)

### DIFF
--- a/src/modal-dialog.component.ts
+++ b/src/modal-dialog.component.ts
@@ -154,7 +154,7 @@ export class ModalDialogComponent implements IModalDialog, OnDestroy {
       options.closeDialogSubject = this._closeDialog$;
 
       this._childInstance['dialogInit'](componentRef, options);
-      (document.activeElement as HTMLElement).blur();
+      document.activeElement != null ? (document.activeElement as HTMLElement).blur(): (document.body as HTMLElement).blur();
     }
     // set options
     this._setOptions(options);


### PR DESCRIPTION
Active element is missing on IE11 when switching between dialogs. 