### PR TITLE
Add Custom Header component visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,42 +96,47 @@ Action button can be of two types:
 - without return value  
   Has no direct effect on dialog. Can be used to trigger some arbitrary functionality (e.g. copy values to clipboard)
 
-Custom Header
+### Custom Header
 1. Create a custom header component that implements `IModalHeaderDialog`.
 
 ```ts
 import {Component} from '@angular/core';
-import {IModalHeaderDialog} from '../../../../src/modal-dialog.interface';
+import {IModalHeaderDialog} from 'ngx-modal-dialog';
 
 @Component({
   selector: 'app-custom-header-modal',
   template: `
-    <p>This component is a custom header.</p>
-    <p><strong>Written By: </strong><b>{{data}}</b></p>
+    <h4>This component is a custom header</h4>
+    <p>Written By: <b>{{title}}</b></p>
   `
 })
 export class CustomHeaderModalComponent implements IModalHeaderDialog {
-  data: string;
+  title: string;
 
   setData(data: any) {
-    this.data = data;
+    this.title = data['title'];
   }
 }
 ```
 
-2. Inject the `ModalDialogService` where you want to open the dialog passing the headerComponent as a new parameter instead of the title attribute:
+2. Inject the `ModalDialogService` where you want to open the dialog passing the headerComponent as a new option parameter instead of the title attribute and change the value of the new parameter headerType to CUSTOM:
 ```ts
 constructor(modalService: ModalDialogService, viewRef: ViewContainerRef) { }
 
-openNewDialog() {
-   this.modalDialogService.openDialog(this.viewContainer, {
-    headerComponent: CustomHeaderModalComponent,
-    childComponent: CustomModalComponent,
-    settings: {
-      closeButtonClass: 'close theme-icon-close'
-    },
-    data: 'Yahima Duarte <layahi@gmail.com>'
-  });
+openCustomHeaderModal() {
+    this.modalDialogService.openDialog(this.viewContainer, {
+      headerComponent: CustomHeaderModalComponent,
+      childComponent: SimpleModalComponent,
+      settings: {
+        closeButtonClass: 'close theme-icon-close',
+        headerType: ModalDialogHeaderType.CUSTOM
+      },
+      data: {
+        title: 'Yahima Duarte <layahi@gmail.com>',
+        text: `Lorem ipsum is placeholder text commonly used in the graphic, print,
+        and publishing industries for previewing layouts and visual mockups.`
+      }
+    });
 }
 ```
 
@@ -255,6 +260,7 @@ interface IModalDialogSettings {
   alertDuration: number;
   buttonClass: string;
   notifyWithAlert: boolean;
+  headerType: ModalDialogHeaderType;
 }
 ```
 
@@ -307,6 +313,8 @@ Style of footer action buttons
 - notifyWithAlert: `number`  
 Default: `true`  
 Define whether modal should alert user when action fails
-
+- headerType: `ModalDialogHeaderType`  
+Default: `TITLE`  
+Define which kind of header would be displayed. If the value is TITLE just the title attribute will be displayed. If the value is CUSTOM and the headerComponent option was defined, the custom header component will be displayed.
 ## License
 Licensed under MIT

--- a/README.md
+++ b/README.md
@@ -96,6 +96,45 @@ Action button can be of two types:
 - without return value  
   Has no direct effect on dialog. Can be used to trigger some arbitrary functionality (e.g. copy values to clipboard)
 
+Custom Header
+1. Create a custom header component that implements `IModalHeaderDialog`.
+
+```ts
+import {Component} from '@angular/core';
+import {IModalHeaderDialog} from '../../../../src/modal-dialog.interface';
+
+@Component({
+  selector: 'app-custom-header-modal',
+  template: `
+    <p>This component is a custom header.</p>
+    <p><strong>Written By: </strong><b>{{data}}</b></p>
+  `
+})
+export class CustomHeaderModalComponent implements IModalHeaderDialog {
+  data: string;
+
+  setData(data: any) {
+    this.data = data;
+  }
+}
+```
+
+2. Inject the `ModalDialogService` where you want to open the dialog passing the headerComponent as a new parameter instead of the title attribute:
+```ts
+constructor(modalService: ModalDialogService, viewRef: ViewContainerRef) { }
+
+openNewDialog() {
+   this.modalDialogService.openDialog(this.viewContainer, {
+    headerComponent: CustomHeaderModalComponent,
+    childComponent: CustomModalComponent,
+    settings: {
+      closeButtonClass: 'close theme-icon-close'
+    },
+    data: 'Yahima Duarte <layahi@gmail.com>'
+  });
+}
+```
+
 ## API
 
 ### ModalDialogService
@@ -122,6 +161,7 @@ Modal heading text
 ```ts
 interface IModalDialogOptions<T> {
   title: string;
+  headerComponent: IModalHeaderDialog;
   childComponent: IModalDialog;
   onClose: ModalDialogOnAction;
   actionButtons: IModalDialogButton[];
@@ -135,6 +175,9 @@ This is generic interface, where `T` is arbitrary type of `data` section.
 #### Interface details:
 - title: `string`  
 Modal heading text
+
+- headerComponent: `any`
+Component type that will be rendered as a header of modal dialog. Component must implement `IModalHeaderDialog` interface.
 
 - childComponent: `any`  
 Component type that will be rendered as a content of modal dialog. Component must implement `IModalDialog` interface.

--- a/demo/package.json
+++ b/demo/package.json
@@ -43,7 +43,7 @@
     "karma-coverage-istanbul-reporter": "~2.0.0",
     "karma-jasmine": "~1.1.1",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "protractor": "~5.3.0",
+    "protractor": "^5.4.0",
     "ts-node": "~5.0.1",
     "tslint": "~5.9.1",
     "typescript": "~2.7.2"

--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -29,6 +29,11 @@
     </div>
     <div class="row mb-2">
       <div class="col">
+        <button class="btn btn-success" type="button" (click)="openCustomHeaderModal()">Dialog with custom header component</button>
+      </div>
+    </div>
+    <div class="row mb-2">
+      <div class="col">
         <button class="btn btn-danger" type="button" (click)="openMultipleModal()">Multiple modal dialogs on top of each other</button>
       </div>
     </div>

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,8 +1,8 @@
 import {Component, ViewContainerRef} from '@angular/core';
-import {ModalDialogService, SimpleModalComponent} from 'ngx-modal-dialog';
 import {CustomModalComponent} from './dialogs/custom-modal.component';
 import {DynamicModalComponent} from './dialogs/dynamic-modal.component';
 import {CustomHeaderModalComponent} from './dialogs/custom-header-modal.component';
+import {ModalDialogHeaderType, ModalDialogService, SimpleModalComponent} from 'ngx-modal-dialog';
 
 @Component({
   selector: 'app-root',
@@ -96,13 +96,17 @@ export class AppComponent {
 
   openCustomHeaderModal() {
     this.modalDialogService.openDialog(this.viewContainer, {
-      title: 'Custom child component',
       headerComponent: CustomHeaderModalComponent,
-      childComponent: CustomModalComponent,
+      childComponent: SimpleModalComponent,
       settings: {
-        closeButtonClass: 'close theme-icon-close'
+        closeButtonClass: 'close theme-icon-close',
+        headerType: ModalDialogHeaderType.CUSTOM
       },
-      data: 'Yahima Duarte <layahi@gmail.com>'
+      data: {
+        title: 'Yahima Duarte <layahi@gmail.com>',
+        text: `Lorem ipsum is placeholder text commonly used in the graphic, print,
+        and publishing industries for previewing layouts and visual mockups.`
+      }
     });
   }
 

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,14 +1,16 @@
-import { Component, ViewContainerRef } from '@angular/core';
-import { ModalDialogService, SimpleModalComponent } from 'ngx-modal-dialog';
-import { CustomModalComponent } from './dialogs/custom-modal.component';
-import { DynamicModalComponent } from './dialogs/dynamic-modal.component';
+import {Component, ViewContainerRef} from '@angular/core';
+import {ModalDialogService, SimpleModalComponent} from 'ngx-modal-dialog';
+import {CustomModalComponent} from './dialogs/custom-modal.component';
+import {DynamicModalComponent} from './dialogs/dynamic-modal.component';
+import {CustomHeaderModalComponent} from './dialogs/custom-header-modal.component';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html'
 })
 export class AppComponent {
-  constructor(private modalDialogService: ModalDialogService, private viewContainer: ViewContainerRef) {}
+  constructor(private modalDialogService: ModalDialogService, private viewContainer: ViewContainerRef) {
+  }
 
   openSimpleModal() {
     this.modalDialogService.openDialog(this.viewContainer, {
@@ -92,6 +94,18 @@ export class AppComponent {
     });
   }
 
+  openCustomHeaderModal() {
+    this.modalDialogService.openDialog(this.viewContainer, {
+      title: 'Custom child component',
+      headerComponent: CustomHeaderModalComponent,
+      childComponent: CustomModalComponent,
+      settings: {
+        closeButtonClass: 'close theme-icon-close'
+      },
+      data: 'Yahima Duarte <layahi@gmail.com>'
+    });
+  }
+
   openDynamicModal() {
     this.modalDialogService.openDialog(this.viewContainer, {
       title: 'Dynamic child component',
@@ -106,30 +120,34 @@ export class AppComponent {
     this.modalDialogService.openDialog(this.viewContainer, {
       title: 'Dialog 1',
       childComponent: SimpleModalComponent,
-      settings: { closeButtonClass: 'close theme-icon-close' },
+      settings: {closeButtonClass: 'close theme-icon-close'},
       placeOnTop: true,
-      data: { text: `
+      data: {
+        text: `
         Lorem ipsum dolor sit amet, consectetur adipiscing elit,
         sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.` }
+        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
+      }
     });
     this.modalDialogService.openDialog(this.viewContainer, {
       title: 'Dialog 2',
       childComponent: SimpleModalComponent,
-      settings: { closeButtonClass: 'close theme-icon-close' },
+      settings: {closeButtonClass: 'close theme-icon-close'},
       placeOnTop: true,
-      data: { text: `
+      data: {
+        text: `
         Lorem ipsum is placeholder text commonly used in the graphic, print,
-        and publishing industries for previewing layouts and visual mockups.` }
+        and publishing industries for previewing layouts and visual mockups.`
+      }
     });
     this.modalDialogService.openDialog(this.viewContainer, {
       title: 'Dialog 3',
       childComponent: SimpleModalComponent,
-      settings: { closeButtonClass: 'close theme-icon-close' },
+      settings: {closeButtonClass: 'close theme-icon-close'},
       placeOnTop: true,
-      data: { text: 'Some text content' }
+      data: {text: 'Some text content'}
     });
   }
 }

--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -1,18 +1,20 @@
-import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {NgModule} from '@angular/core';
 
-import { AppComponent } from './app.component';
-import { CustomModalComponent } from './dialogs/custom-modal.component';
-import { ModalDialogModule } from 'ngx-modal-dialog';
-import { DynamicModalComponent } from './dialogs/dynamic-modal.component';
+import {AppComponent} from './app.component';
+import {CustomModalComponent} from './dialogs/custom-modal.component';
+import {ModalDialogModule} from 'ngx-modal-dialog';
+import {DynamicModalComponent} from './dialogs/dynamic-modal.component';
+import {CustomHeaderModalComponent} from './dialogs/custom-header-modal.component';
 
 @NgModule({
-  declarations: [AppComponent, CustomModalComponent, DynamicModalComponent],
+  declarations: [AppComponent, CustomModalComponent, DynamicModalComponent, CustomHeaderModalComponent],
   imports: [
     BrowserModule,
     ModalDialogModule.forRoot()
   ],
-  entryComponents: [CustomModalComponent, DynamicModalComponent],
+  entryComponents: [CustomModalComponent, DynamicModalComponent, CustomHeaderModalComponent],
   bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {
+}

--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -1,9 +1,9 @@
 import {BrowserModule} from '@angular/platform-browser';
 import {NgModule} from '@angular/core';
+import { ModalDialogModule } from 'ngx-modal-dialog';
 
 import {AppComponent} from './app.component';
 import {CustomModalComponent} from './dialogs/custom-modal.component';
-import {ModalDialogModule} from 'ngx-modal-dialog';
 import {DynamicModalComponent} from './dialogs/dynamic-modal.component';
 import {CustomHeaderModalComponent} from './dialogs/custom-header-modal.component';
 

--- a/demo/src/app/dialogs/custom-header-modal.component.ts
+++ b/demo/src/app/dialogs/custom-header-modal.component.ts
@@ -1,17 +1,17 @@
 import {Component} from '@angular/core';
-import {IModalHeaderDialog} from '../../../../src/modal-dialog.interface';
+import {IModalHeaderDialog} from 'ngx-modal-dialog';
 
 @Component({
   selector: 'app-custom-header-modal',
   template: `
-    <p>This component is a custom header.</p>
-    <p>Written By: <b>{{data}}</b></p>
+    <h4>This component is a custom header</h4>
+    <p>Written By: <b>{{title}}</b></p>
   `
 })
 export class CustomHeaderModalComponent implements IModalHeaderDialog {
-  data: string;
+  title: string;
 
   setData(data: any) {
-    this.data = data;
+    this.title = data['title'];
   }
 }

--- a/demo/src/app/dialogs/custom-header-modal.component.ts
+++ b/demo/src/app/dialogs/custom-header-modal.component.ts
@@ -1,0 +1,17 @@
+import {Component} from '@angular/core';
+import {IModalHeaderDialog} from '../../../../src/modal-dialog.interface';
+
+@Component({
+  selector: 'app-custom-header-modal',
+  template: `
+    <p>This component is a custom header.</p>
+    <p>Written By: <b>{{data}}</b></p>
+  `
+})
+export class CustomHeaderModalComponent implements IModalHeaderDialog {
+  data: string;
+
+  setData(data: any) {
+    this.data = data;
+  }
+}

--- a/demo/src/app/dialogs/custom-modal.component.ts
+++ b/demo/src/app/dialogs/custom-modal.component.ts
@@ -1,5 +1,5 @@
-import { IModalDialog, IModalDialogOptions } from 'ngx-modal-dialog';
 import { Component, ComponentRef } from '@angular/core';
+import {IModalDialog, IModalDialogOptions} from 'ngx-modal-dialog';
 
 @Component({
   selector: 'app-custom-modal',

--- a/demo/src/app/dialogs/dynamic-modal.component.ts
+++ b/demo/src/app/dialogs/dynamic-modal.component.ts
@@ -1,5 +1,5 @@
-import { IModalDialog, IModalDialogOptions } from 'ngx-modal-dialog';
 import { Component, ComponentRef } from '@angular/core';
+import {IModalDialog, IModalDialogOptions} from 'ngx-modal-dialog';
 
 @Component({
   selector: 'app-dynamic-modal',

--- a/src/modal-dialog.ad-header.directive.ts
+++ b/src/modal-dialog.ad-header.directive.ts
@@ -1,0 +1,8 @@
+import { Directive, ViewContainerRef } from '@angular/core';
+
+@Directive({
+  selector: '[ad-header]',
+})
+export class AdHeaderDirective {
+  constructor(public viewContainerRef: ViewContainerRef) { }
+}

--- a/src/modal-dialog.component.ts
+++ b/src/modal-dialog.component.ts
@@ -17,9 +17,9 @@ import {
     IModalHeaderDialog,
     ModalDialogOnAction
 } from './modal-dialog.interface';
-import {from, Observable, Subject} from 'rxjs';
-import {AdHeaderDirective} from './modal-dialog.ad-header.directive';
-import {ModalDialogHeaderType} from './modal-dialog.header-type';
+import { from, Observable, Subject } from 'rxjs';
+import { AdHeaderDirective } from './modal-dialog.ad-header.directive';
+import { ModalDialogHeaderType } from './modal-dialog.header-type';
 
 /**
  * Modal dialog component

--- a/src/modal-dialog.component.ts
+++ b/src/modal-dialog.component.ts
@@ -1,21 +1,25 @@
 ﻿import {
-  Component,
-  ComponentRef,
-  ComponentFactoryResolver,
-  ViewContainerRef,
-  ViewChild,
-  OnDestroy, OnInit,
-  HostListener, ElementRef
+    Component,
+    ComponentFactoryResolver,
+    ComponentRef,
+    ElementRef,
+    HostListener,
+    OnDestroy,
+    OnInit,
+    ViewChild,
+    ViewContainerRef
 } from '@angular/core';
 import {
-  IModalDialog,
-  IModalDialogOptions,
-  IModalDialogButton,
-  IModalDialogSettings, ModalDialogOnAction,
-  IModalHeaderDialog
+    IModalDialog,
+    IModalDialogButton,
+    IModalDialogOptions,
+    IModalDialogSettings,
+    IModalHeaderDialog,
+    ModalDialogOnAction
 } from './modal-dialog.interface';
-import { Observable, Subject, from } from 'rxjs';
-import { AdHeaderDirective } from './modal-dialog.ad-header.directive';
+import {from, Observable, Subject} from 'rxjs';
+import {AdHeaderDirective} from './modal-dialog.ad-header.directive';
+import {ModalDialogHeaderType} from './modal-dialog.header-type';
 
 /**
  * Modal dialog component
@@ -57,9 +61,6 @@ import { AdHeaderDirective } from './modal-dialog.ad-header.directive';
         -moz-animation-name: shake;
         animation-name: shake;
       }
-      .modal-title {
-        display: inline-flex;
-      }
   `],
   template: `
     <div *ngIf="settings.overlayClass && showOverlay" [ngClass]="[settings.overlayClass, animateOverlayClass]"></div> 
@@ -69,7 +70,7 @@ import { AdHeaderDirective } from './modal-dialog.ad-header.directive';
           <div [ngClass]="settings.headerClass">
             <div [ngClass]="settings.headerTitleClass">
               <ng-template ad-header></ng-template>
-              <h4 *ngIf="title">{{title}}</h4>
+              <h4 *ngIf="settings.headerType === 1">{{title}}</h4>
             </div>
             <button (click)="close()" *ngIf="!actionButtons || !actionButtons.length" type="button"
                     [title]="settings.closeButtonTitle"
@@ -112,7 +113,8 @@ export class ModalDialogComponent implements IModalDialog, OnDestroy, OnInit {
     alertClass: 'ngx-modal-shake',
     alertDuration: 250,
     notifyWithAlert: true,
-    buttonClass: 'btn btn-primary'
+    buttonClass: 'btn btn-primary',
+    headerType: ModalDialogHeaderType.TITLE
   };
   public actionButtons: IModalDialogButton[];
   public title: string;
@@ -172,7 +174,10 @@ export class ModalDialogComponent implements IModalDialog, OnDestroy, OnInit {
         (document.activeElement as HTMLElement).blur() :
         (document.body as HTMLElement).blur();
     }
-    if (options.headerComponent) {
+    // set options
+    this._setOptions(options);
+
+    if (this.settings.headerType === ModalDialogHeaderType.CUSTOM && options.headerComponent) {
       const factory = this.componentFactoryResolver.resolveComponentFactory(options.headerComponent);
 
       const viewContainerRef = this.adHeader.viewContainerRef;
@@ -180,9 +185,6 @@ export class ModalDialogComponent implements IModalDialog, OnDestroy, OnInit {
       const componentRef = viewContainerRef.createComponent(factory);
       (<IModalHeaderDialog>componentRef.instance).setData(options.data);
     }
-
-    // set options
-    this._setOptions(options);
   }
 
   ngOnInit() {

--- a/src/modal-dialog.header-type.ts
+++ b/src/modal-dialog.header-type.ts
@@ -1,0 +1,3 @@
+export enum ModalDialogHeaderType {
+  TITLE = 1, CUSTOM = 2
+}

--- a/src/modal-dialog.interface.ts
+++ b/src/modal-dialog.interface.ts
@@ -5,8 +5,13 @@ export interface IModalDialog {
   dialogInit: (reference: ComponentRef<IModalDialog>, options: Partial<IModalDialogOptions<any>>) => void;
 }
 
+export interface IModalHeaderDialog {
+  setData(data: any): void;
+}
+
 export interface IModalDialogOptions<T> {
   title: string;
+  headerComponent: any;
   childComponent: any;
   onClose: () => Promise<any> | Observable<any> | boolean;
   actionButtons: IModalDialogButton[];

--- a/src/modal-dialog.interface.ts
+++ b/src/modal-dialog.interface.ts
@@ -1,5 +1,6 @@
-﻿import { ComponentRef } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
+﻿import {ComponentRef} from '@angular/core';
+import {Observable, Subject} from 'rxjs';
+import {ModalDialogHeaderType} from './modal-dialog.header-type';
 
 export interface IModalDialog {
   dialogInit: (reference: ComponentRef<IModalDialog>, options: Partial<IModalDialogOptions<any>>) => void;
@@ -47,4 +48,5 @@ export interface IModalDialogSettings {
   alertDuration: number;
   buttonClass: string;
   notifyWithAlert: boolean;
+  headerType: ModalDialogHeaderType;
 }

--- a/src/modal-dialog.module.ts
+++ b/src/modal-dialog.module.ts
@@ -6,6 +6,7 @@ import { ModalDialogInstanceService } from './modal-dialog-instance.service';
 // modules
 import { CommonModule } from '@angular/common';
 import { NgModule, ModuleWithProviders, InjectionToken, SkipSelf, Optional } from '@angular/core';
+import { AdHeaderDirective } from './modal-dialog.ad-header.directive';
 
 /**
  * Guard to make sure we have single initialization of forRoot
@@ -15,7 +16,7 @@ export const MODAL_DIALOG_FORROOT_GUARD = new InjectionToken<ModalDialogModule>(
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [ModalDialogComponent, SimpleModalComponent],
+  declarations: [ModalDialogComponent, SimpleModalComponent, AdHeaderDirective],
   entryComponents: [ModalDialogComponent, SimpleModalComponent],
   exports: [ModalDialogComponent, SimpleModalComponent],
   providers: [ModalDialogService]

--- a/src/simple-modal.component.ts
+++ b/src/simple-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentRef } from '@angular/core';
+import { Component, ComponentRef, HostBinding } from '@angular/core';
 import { IModalDialog, IModalDialogOptions } from './modal-dialog.interface';
 
 export interface ISimpleModalDataOptions {
@@ -8,13 +8,10 @@ export interface ISimpleModalDataOptions {
 @Component({
   selector: 'simple-modal-dialog',
   template: ``,
-  styles: [':host { display: block; }'],
-  host: {
-    '[innerHTML]': 'text'
-  }
+  styles: [':host { display: block; }']
 })
 export class SimpleModalComponent implements IModalDialog {
-  text: string;
+    @HostBinding('innerHTML') text: string;
 
   /**
    * Initialize dialog with simple HTML content

--- a/tests/modal-dialog.component.spec.ts
+++ b/tests/modal-dialog.component.spec.ts
@@ -3,10 +3,11 @@ import { TestBed, ComponentFixture, fakeAsync, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { ModalDialogComponent } from '../src/modal-dialog.component';
-import {IModalDialog, IModalDialogOptions, IModalHeaderDialog} from '../src/modal-dialog.interface';
+import { IModalDialog, IModalDialogOptions, IModalHeaderDialog } from '../src/modal-dialog.interface';
 import { CommonModule } from '@angular/common';
 import { Subject, of } from 'rxjs';
-import {AdHeaderDirective} from '../src/modal-dialog.ad-header.directive';
+import { AdHeaderDirective } from '../src/modal-dialog.ad-header.directive';
+import { ModalDialogHeaderType } from '../src/modal-dialog.header-type';
 
 let fixture: ComponentFixture<ModalDialogComponent>;
 
@@ -271,6 +272,10 @@ describe('ModalDialog.Component:', () => {
       component.dialogInit(fixture.componentRef, {
           headerComponent: DummyHeaderComponent,
           childComponent: DummyComponent,
+          settings: {
+              closeButtonClass: 'close theme-icon-close',
+              headerType: ModalDialogHeaderType.CUSTOM
+          },
           data: data
       });
 

--- a/tests/modal-dialog.component.spec.ts
+++ b/tests/modal-dialog.component.spec.ts
@@ -3,9 +3,10 @@ import { TestBed, ComponentFixture, fakeAsync, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { ModalDialogComponent } from '../src/modal-dialog.component';
-import { IModalDialog, IModalDialogOptions } from '../src/modal-dialog.interface';
+import {IModalDialog, IModalDialogOptions, IModalHeaderDialog} from '../src/modal-dialog.interface';
 import { CommonModule } from '@angular/common';
 import { Subject, of } from 'rxjs';
+import {AdHeaderDirective} from '../src/modal-dialog.ad-header.directive';
 
 let fixture: ComponentFixture<ModalDialogComponent>;
 
@@ -29,6 +30,18 @@ class DummyComponent implements IModalDialog {
   }
 }
 
+@Component({
+    selector: 'dummy-header',
+    template: `<h1>Hello {{props}}!</h1>`
+})
+class DummyHeaderComponent implements IModalHeaderDialog {
+    props: any;
+
+    setData(data: any) {
+        this.props = data['headerTitle'];
+    }
+}
+
 describe('ModalDialog.Component:', () => {
   let component: ModalDialogComponent;
   let sampleText: string;
@@ -42,10 +55,10 @@ describe('ModalDialog.Component:', () => {
 
     let module = TestBed.configureTestingModule({
       imports: [CommonModule],
-      declarations: [ModalDialogComponent, DummyComponent]
+      declarations: [ModalDialogComponent, DummyComponent, DummyHeaderComponent, AdHeaderDirective]
     });
     module.overrideModule(BrowserDynamicTestingModule, {
-      set: { entryComponents: [DummyComponent] }
+      set: { entryComponents: [DummyComponent, DummyHeaderComponent] }
     });
 
     fixture = module.createComponent(ModalDialogComponent);
@@ -54,7 +67,7 @@ describe('ModalDialog.Component:', () => {
 
   beforeEach(() => {
     sampleText = 'sample text';
-    data = { some: 'data' };
+    data = { some: 'data', headerTitle: 'World' };
     onCloseWrapper = {
       onClose: () => new Promise<string>((resolve: any) => {
         resolve();
@@ -252,6 +265,27 @@ describe('ModalDialog.Component:', () => {
 
     expect(innerComponent).toBeDefined('modal dialog body should be defined');
     expect(innerComponent.innerHTML).toContain(testString);
+  }));
+
+  it('should inject new header and child component', fakeAsync(() => {
+      component.dialogInit(fixture.componentRef, {
+          headerComponent: DummyHeaderComponent,
+          childComponent: DummyComponent,
+          data: data
+      });
+
+      fixture.detectChanges();
+      // flush async calls
+      tick();
+      fixture.detectChanges();
+
+      const innerComponent = fixture.debugElement.query(By.css('.modal-body')).nativeElement;
+      expect(innerComponent).toBeDefined('modal dialog body should be defined');
+
+      const innerHeaderComponent = fixture.debugElement.query(By.css('.modal-title')).nativeElement;
+      expect(innerHeaderComponent).toBeDefined('modal dialog custom header should be defined');
+      expect(innerHeaderComponent.innerHTML).toContain('Hello World!');
+
   }));
 
   it('should close dialog from child component', fakeAsync(() => {


### PR DESCRIPTION
The objective of this change is to have the possibility of display custom component, not just in the body of the modal, but also in the header.

- Added a new parameter in IModalDialogOptions named **headerComponent** used to store the custom Header component to be displayed.
- Added a new parameter in IModalDialogSettings named **headerType** that will have the default value **TITLE** or can be changed with the value **CUSTOM**. If the second value is defined, the **headerComponent** parameter becomes mandatory.
- New Unit test was added to test this new modal dialog behavior.
- A new button with the title "Dialog with custom header component" was added in the demo project to display the new case.