### PR TITLE
(fix) close dialog only on mousedown

### DIFF
--- a/src/modal-dialog.component.ts
+++ b/src/modal-dialog.component.ts
@@ -129,7 +129,7 @@ export class ModalDialogComponent implements IModalDialog, OnDestroy, OnInit {
               private componentFactoryResolver: ComponentFactoryResolver) {
   }
 
-  @HostListener('click', ['$event'])
+  @HostListener('mousedown', ['$event'])
   onClick(event: any): void {
     if (event.target !== this.dialogElement.nativeElement) {
       return;


### PR DESCRIPTION
This patch is fixing the problem that the modal is getting closed, when someone clicks the mousebutton withint he modal an releases the button not within the context of the model. As many people use the mouse to mark some text within the modal it sometimes close, when they are going wild with the mouse and leaving the mouse button.